### PR TITLE
🎨 Palette: Search Discoverability & Empty States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-03-03 - Navigation Accessibility Patterns
 **Learning:** Icon-only buttons (like floating 'Back to Top' and 'Back to Home') and interactive menu toggles require explicit ARIA attributes to be accessible to screen reader users. Specifically, `aria-label` provides a textual alternative, and `aria-expanded` combined with `aria-controls` communicates the state of collapsible menus.
 **Action:** Always include `aria-label` for SVG-only buttons and synchronize `aria-expanded` via JavaScript for any toggle interactions.
+
+## 2026-03-03 - Keyboard Shortcut Discoverability & ID Inconsistency
+**Learning:** Global keyboard shortcuts (like '/' for search) are powerful but often remain hidden features. Promoting them via placeholder hints like "(按 / 搜尋)" significantly improves discoverability without cluttering the UI. Additionally, a mature project may have inconsistent element IDs (e.g., `#searchInput` vs `#kw`) for similar components across pages, necessitating robust selector logic in global scripts.
+**Action:** Append shortcut hints to input placeholders dynamically. Ensure global selectors handle all common ID variants used in the codebase.

--- a/aa.html
+++ b/aa.html
@@ -53,6 +53,9 @@
     <div id="pet-list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         <!-- 寵物資料將由 JavaScript 動態載入 -->
     </div>
+    <div id="no-results" class="text-center py-12 hidden">
+        <p class="text-2xl text-slate-400">找不到符合條件的寵物或技能。</p>
+    </div>
 </div>
 
 <script>
@@ -6074,6 +6077,8 @@ document.addEventListener("DOMContentLoaded", () => {
         petCards.forEach(card => {
             card.style.display = '';
         });
+        document.getElementById('no-results').classList.add('hidden');
+        document.getElementById('pet-list').classList.remove('hidden');
     }
 
     function filterPets() {
@@ -6083,6 +6088,8 @@ document.addEventListener("DOMContentLoaded", () => {
             return;
         }
         const petCards = document.querySelectorAll('.pet-card');
+        const noResults = document.getElementById('no-results');
+        let visibleCount = 0;
 
         petCards.forEach(card => {
             const petName = card.querySelector('h2').textContent.toLowerCase();
@@ -6092,10 +6099,19 @@ document.addEventListener("DOMContentLoaded", () => {
             
             if (matches) {
                 card.style.display = '';
+                visibleCount++;
             } else {
                 card.style.display = 'none';
             }
         });
+
+        if (visibleCount === 0) {
+            noResults.classList.remove('hidden');
+            document.getElementById('pet-list').classList.add('hidden');
+        } else {
+            noResults.classList.add('hidden');
+            document.getElementById('pet-list').classList.remove('hidden');
+        }
     }
 
     searchButton.addEventListener('click', filterPets);

--- a/nav.js
+++ b/nav.js
@@ -164,6 +164,11 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     // --- 6. Global Keyboard Shortcut for Search ---
+    const searchInputEl = document.getElementById('searchInput') || document.getElementById('kw');
+    if (searchInputEl && searchInputEl.placeholder && !searchInputEl.placeholder.includes('/')) {
+        searchInputEl.placeholder += ' (按 / 搜尋)';
+    }
+
     document.addEventListener('keydown', (e) => {
         // Press '/' to focus search input, if not already focusing an input
         if (e.key === '/' && !['INPUT', 'TEXTAREA', 'SELECT'].includes(document.activeElement.tagName)) {


### PR DESCRIPTION
I've implemented a pair of search-focused micro-UX improvements to enhance the browsing experience:

1. **Global Shortcut Hint:** Most pages have a search feature accessible via the `/` key, but this was a "hidden" feature. I updated `nav.js` to dynamically append `(按 / 搜尋)` to placeholders for elements with IDs `searchInput` or `kw`. This makes the power-user shortcut discoverable for everyone.
2. **Search Empty State:** On the Pet Skills page (`aa.html`), searching for a non-existent term would previously leave the screen confusingly blank. I added a "no results" message that appears when no pets or skills match the query, providing immediate feedback.

Both changes were implemented surgically to maintain the repository's existing line-ending conventions and stay well within the 50-line limit. Visual verification was performed via Playwright across multiple pages.

---
*PR created automatically by Jules for task [10180999674681191555](https://jules.google.com/task/10180999674681191555) started by @MisakiYu1003*