### PR TITLE
🎨 Palette: Item Card Accessibility Improvement

### DIFF
--- a/rich.html
+++ b/rich.html
@@ -29,6 +29,10 @@
             border-color: var(--rich-card-selected-border);
             box-shadow: 0 0 15px var(--rich-card-selected-border);
         }
+        .item-card:focus-visible {
+            outline: 3px solid var(--rich-card-selected-border);
+            outline-offset: 2px;
+        }
         .comparison-area {
             background-color: var(--rich-comparison-bg);
             backdrop-filter: blur(10px);
@@ -77,7 +81,7 @@
         }
         h1 { color: var(--rich-text-slate-100); }
         header p { color: var(--rich-text-slate-400); }
-        #item-groups h2 { 
+        #item-groups h2 {
             color: var(--rich-text-slate-100);
             border-left-color: var(--link-color);
         }
@@ -1694,7 +1698,7 @@
                 const item = { id: `item-${index}` };
                 item.name = lines[0].trim();
                 item.type = lines[1].trim();
-                
+
                 // Parse stats
                 item.stats = {};
                 const statsLine = lines[2];
@@ -1731,7 +1735,7 @@
 
                 return item;
             }).filter(item => item && item.name); // Filter out any null or invalid items
-            
+
             // Deduplicate items based on name
             const uniqueItems = [];
             const names = new Set();
@@ -1757,7 +1761,7 @@
                 (acc[item.series] = acc[item.series] || []).push(item);
                 return acc;
             }, {});
-            
+
             // Sort groups by highest item level within the group
             const sortedGroupKeys = Object.keys(groupedItems).sort((a, b) => {
                 const maxLevelA = Math.max(...groupedItems[a].map(i => i.itemLevel));
@@ -1779,7 +1783,7 @@
                 container.appendChild(groupContainer);
             }
         }
-        
+
         function getNameGradientClass(itemLevel) {
             if (itemLevel >= 300) return 'item-name-gradient-gold';
             if (itemLevel >= 280) return 'item-name-gradient-purple';
@@ -1794,7 +1798,13 @@
                 .join('');
 
             return `
-                <div id="${item.id}" class="item-card rounded-lg p-4 flex flex-col ${isSelected ? 'selected' : ''}" onclick="toggleItemSelection('${item.id}')">
+                <div id="${item.id}"
+                     class="item-card rounded-lg p-4 flex flex-col ${isSelected ? 'selected' : ''}"
+                     onclick="toggleItemSelection('${item.id}')"
+                     onkeydown="if(event.key === 'Enter' || event.key === ' ') { event.preventDefault(); toggleItemSelection('${item.id}'); }"
+                     tabindex="0"
+                     role="button"
+                     aria-pressed="${isSelected}">
                     <h3 class="text-xl font-bold mb-2 ${getNameGradientClass(item.itemLevel)}">${item.name}</h3>
                     <div class="text-xs text-slate-400 mb-3 space-x-4">
                         <span>物品等級: ${item.itemLevel}</span>
@@ -1819,7 +1829,7 @@
                 tableContainer.innerHTML = '<p class="text-center text-slate-400">請至少選擇一件物品進行比較。</p>';
                 return;
             }
-            
+
             container.classList.remove('translate-y-full');
             deselectBtn.classList.remove('hidden');
 
@@ -1839,7 +1849,7 @@
             allStatKeys.forEach(key => {
                 maxValues[key] = Math.max(...selectedItems.map(item => item.stats[key] || 0));
             });
-            
+
             let tableHtml = `
                 <table class="w-full text-left border-collapse">
                     <thead>
@@ -1875,26 +1885,32 @@
         // --- EVENT HANDLING ---
         function toggleItemSelection(itemId) {
             const itemIndex = selectedItems.findIndex(item => item.id === itemId);
+            let isSelected = false;
             if (itemIndex > -1) {
                 selectedItems.splice(itemIndex, 1);
             } else {
                 const itemToAdd = allItems.find(item => item.id === itemId);
                 if (itemToAdd) {
                     selectedItems.push(itemToAdd);
+                    isSelected = true;
                 }
             }
-            
+
             const card = document.getElementById(itemId);
             if (card) {
                 card.classList.toggle('selected');
+                card.setAttribute('aria-pressed', isSelected);
             }
 
             renderComparison();
         }
-        
+
         function deselectAllItems() {
             selectedItems = [];
-            document.querySelectorAll('.item-card.selected').forEach(card => card.classList.remove('selected'));
+            document.querySelectorAll('.item-card.selected').forEach(card => {
+                card.classList.remove('selected');
+                card.setAttribute('aria-pressed', 'false');
+            });
             renderComparison();
         }
 
@@ -1903,7 +1919,7 @@
             allItems = parseRawData(rawData);
             renderItems();
             renderComparison();
-            
+
             document.getElementById('deselect-all-btn').addEventListener('click', deselectAllItems);
 
             const searchButton = document.getElementById('searchButton');
@@ -1917,9 +1933,9 @@
                 itemCards.forEach(card => {
                     const itemName = card.querySelector('h3').textContent.toLowerCase();
                     const itemDescription = card.querySelector('.text-xs.text-slate-400').textContent.toLowerCase();
-                    
+
                     const matches = itemName.includes(searchTerm) || itemDescription.includes(searchTerm);
-                    
+
                     if (matches) {
                         card.style.display = '';
                     } else {


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Improved the accessibility and keyboard interactivity of the item comparison cards in `rich.html`.

### 🎯 Why: The user problem it solves
Previously, item cards were implemented as non-semantic `div` elements that were only clickable with a mouse. Users navigating via keyboard (e.g., Tab key) could not focus on or select items for comparison, and screen reader users were not informed of the elements' interactive nature or selection state.

### 📸 Before/After: Screenshots if visual change
The enhancement adds a visible 3px outline when a card is focused via keyboard (using `focus-visible`). Mouse users see no change to the hover effect.

### ♿ Accessibility: Any a11y improvements made
- **Keyboard Navigation:** Users can now Tab to each item card and press `Enter` or `Space` to select/deselect them.
- **Semantic Roles:** Added `role="button"` to inform screen readers that these cards are interactive.
- **State Feedback:** Added `aria-pressed` to communicate whether an item is currently selected for comparison.
- **Focus Indicators:** Added dedicated focus-visible styles to ensure keyboard users know where they are on the page.

---
*PR created automatically by Jules for task [15095130827562980551](https://jules.google.com/task/15095130827562980551) started by @MisakiYu1003*