### PR TITLE
🎨 Palette: Improve Accessibility and Search UX in rich.html

### DIFF
--- a/rich.html
+++ b/rich.html
@@ -29,6 +29,10 @@
             border-color: var(--rich-card-selected-border);
             box-shadow: 0 0 15px var(--rich-card-selected-border);
         }
+        .item-card:focus-visible {
+            outline: 3px solid var(--rich-card-selected-border);
+            outline-offset: 2px;
+        }
         .comparison-area {
             background-color: var(--rich-comparison-bg);
             backdrop-filter: blur(10px);
@@ -77,7 +81,7 @@
         }
         h1 { color: var(--rich-text-slate-100); }
         header p { color: var(--rich-text-slate-400); }
-        #item-groups h2 { 
+        #item-groups h2 {
             color: var(--rich-text-slate-100);
             border-left-color: var(--link-color);
         }
@@ -105,7 +109,7 @@
             <p>點擊物品卡片以加入或移出比較列表。(資料版本為2025/08/01遊戲市中活動擷取)</p>
             <div class="mt-4 max-w-lg mx-auto">
                 <div class="flex">
-                    <input type="text" id="searchInput" class="w-full px-4 py-2 border rounded-l-lg focus:outline-none" placeholder="搜尋飾品名稱或敘述..." style="color: black;">
+                    <input type="text" id="searchInput" class="w-full px-4 py-2 border rounded-l-lg focus:outline-none" placeholder="搜尋飾品名稱或敘述... (按 / 搜尋)" style="color: black;">
                     <button id="searchButton" class="bg-blue-500 hover:bg-blue-600 text-white px-6 py-2">搜尋</button>
                     <button id="clearButton" class="bg-gray-500 hover:bg-gray-600 text-white px-6 py-2 rounded-r-lg">清除</button>
                 </div>
@@ -1694,7 +1698,7 @@
                 const item = { id: `item-${index}` };
                 item.name = lines[0].trim();
                 item.type = lines[1].trim();
-                
+
                 // Parse stats
                 item.stats = {};
                 const statsLine = lines[2];
@@ -1731,7 +1735,7 @@
 
                 return item;
             }).filter(item => item && item.name); // Filter out any null or invalid items
-            
+
             // Deduplicate items based on name
             const uniqueItems = [];
             const names = new Set();
@@ -1757,7 +1761,7 @@
                 (acc[item.series] = acc[item.series] || []).push(item);
                 return acc;
             }, {});
-            
+
             // Sort groups by highest item level within the group
             const sortedGroupKeys = Object.keys(groupedItems).sort((a, b) => {
                 const maxLevelA = Math.max(...groupedItems[a].map(i => i.itemLevel));
@@ -1779,7 +1783,7 @@
                 container.appendChild(groupContainer);
             }
         }
-        
+
         function getNameGradientClass(itemLevel) {
             if (itemLevel >= 300) return 'item-name-gradient-gold';
             if (itemLevel >= 280) return 'item-name-gradient-purple';
@@ -1794,7 +1798,9 @@
                 .join('');
 
             return `
-                <div id="${item.id}" class="item-card rounded-lg p-4 flex flex-col ${isSelected ? 'selected' : ''}" onclick="toggleItemSelection('${item.id}')">
+                <div id="${item.id}" class="item-card rounded-lg p-4 flex flex-col ${isSelected ? 'selected' : ''}"
+                     onclick="toggleItemSelection('${item.id}')"
+                     role="button" tabindex="0" aria-pressed="${isSelected}">
                     <h3 class="text-xl font-bold mb-2 ${getNameGradientClass(item.itemLevel)}">${item.name}</h3>
                     <div class="text-xs text-slate-400 mb-3 space-x-4">
                         <span>物品等級: ${item.itemLevel}</span>
@@ -1819,7 +1825,7 @@
                 tableContainer.innerHTML = '<p class="text-center text-slate-400">請至少選擇一件物品進行比較。</p>';
                 return;
             }
-            
+
             container.classList.remove('translate-y-full');
             deselectBtn.classList.remove('hidden');
 
@@ -1839,7 +1845,7 @@
             allStatKeys.forEach(key => {
                 maxValues[key] = Math.max(...selectedItems.map(item => item.stats[key] || 0));
             });
-            
+
             let tableHtml = `
                 <table class="w-full text-left border-collapse">
                     <thead>
@@ -1883,15 +1889,16 @@
                     selectedItems.push(itemToAdd);
                 }
             }
-            
+
             const card = document.getElementById(itemId);
             if (card) {
-                card.classList.toggle('selected');
+                const isSelectedNow = card.classList.toggle('selected');
+                card.setAttribute('aria-pressed', isSelectedNow);
             }
 
             renderComparison();
         }
-        
+
         function deselectAllItems() {
             selectedItems = [];
             document.querySelectorAll('.item-card.selected').forEach(card => card.classList.remove('selected'));
@@ -1903,8 +1910,16 @@
             allItems = parseRawData(rawData);
             renderItems();
             renderComparison();
-            
+
             document.getElementById('deselect-all-btn').addEventListener('click', deselectAllItems);
+
+            // Add keyboard support for item cards
+            document.getElementById('item-groups').addEventListener('keydown', (e) => {
+                if ((e.key === 'Enter' || e.key === ' ') && e.target.classList.contains('item-card')) {
+                    e.preventDefault();
+                    e.target.click();
+                }
+            });
 
             const searchButton = document.getElementById('searchButton');
             const searchInput = document.getElementById('searchInput');
@@ -1917,9 +1932,9 @@
                 itemCards.forEach(card => {
                     const itemName = card.querySelector('h3').textContent.toLowerCase();
                     const itemDescription = card.querySelector('.text-xs.text-slate-400').textContent.toLowerCase();
-                    
+
                     const matches = itemName.includes(searchTerm) || itemDescription.includes(searchTerm);
-                    
+
                     if (matches) {
                         card.style.display = '';
                     } else {
@@ -1945,6 +1960,7 @@
             clearButton.addEventListener('click', () => {
                 searchInput.value = '';
                 showAllItems();
+                searchInput.focus();
             });
         });
     </script>


### PR DESCRIPTION
💡 What: I've enhanced the Accessories Comparison page (`rich.html`) with several micro-UX and accessibility improvements.

🎯 Why: To make the interface more keyboard-friendly and intuitive. Users can now browse and select items for comparison without a mouse, and the search interaction is smoother.

♿ Accessibility:
- Item cards are now focusable via the Tab key and identifiable as buttons to screen readers.
- Keyboard-only users can toggle item selection using the Space or Enter keys.
- Clear visual focus indicators (outlines) have been added for focused items.
- `aria-pressed` state communicates whether an item is selected for comparison.
- Added a discoverable hint for the existing global `/` search shortcut.

Visual changes:
- Focus state: `outline: 3px solid var(--rich-card-selected-border)`.
- Search placeholder: Updated with `(按 / 搜尋)`.

---
*PR created automatically by Jules for task [12348656062345897223](https://jules.google.com/task/12348656062345897223) started by @MisakiYu1003*