### PR TITLE
🎨 Palette: Polished Search UX and Component Accessibility

### DIFF
--- a/aa.html
+++ b/aa.html
@@ -44,7 +44,7 @@
     
     <div class="mb-8 max-w-lg mx-auto">
         <div class="flex">
-            <input type="text" id="searchInput" class="w-full px-4 py-2 border rounded-l-lg focus:outline-none" placeholder="搜尋寵物或技能名稱..." style="color: black;">
+            <input type="text" id="searchInput" class="w-full px-4 py-2 border rounded-l-lg focus:outline-none" placeholder="搜尋寵物或技能名稱... (按 / 搜尋)" style="color: black;">
             <button id="searchButton" class="bg-blue-500 hover:bg-blue-600 text-white px-6 py-2">搜尋</button>
             <button id="clearButton" class="bg-gray-500 hover:bg-gray-600 text-white px-6 py-2 rounded-r-lg">清除</button>
         </div>
@@ -6107,6 +6107,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     clearButton.addEventListener('click', () => {
         searchInput.value = '';
+        searchInput.focus();
         showAllPets();
     });
 });

--- a/achievement.html
+++ b/achievement.html
@@ -19,7 +19,7 @@
   </p>
 
   <div class="filters">
-    <input id="kw" type="text" placeholder="關鍵字搜尋">
+    <input id="kw" type="text" placeholder="關鍵字搜尋 (按 / 搜尋)">
     <select id="cat"><option>全部</option></select>
     <select id="subcat"><option>全部</option></select>
     <select id="diff"><option>全部</option></select>

--- a/rich.html
+++ b/rich.html
@@ -29,6 +29,10 @@
             border-color: var(--rich-card-selected-border);
             box-shadow: 0 0 15px var(--rich-card-selected-border);
         }
+        .item-card:focus-visible {
+            outline: 3px solid var(--rich-card-selected-border);
+            outline-offset: 2px;
+        }
         .comparison-area {
             background-color: var(--rich-comparison-bg);
             backdrop-filter: blur(10px);
@@ -105,7 +109,7 @@
             <p>點擊物品卡片以加入或移出比較列表。(資料版本為2025/08/01遊戲市中活動擷取)</p>
             <div class="mt-4 max-w-lg mx-auto">
                 <div class="flex">
-                    <input type="text" id="searchInput" class="w-full px-4 py-2 border rounded-l-lg focus:outline-none" placeholder="搜尋飾品名稱或敘述..." style="color: black;">
+                    <input type="text" id="searchInput" class="w-full px-4 py-2 border rounded-l-lg focus:outline-none" placeholder="搜尋飾品名稱或敘述... (按 / 搜尋)" style="color: black;">
                     <button id="searchButton" class="bg-blue-500 hover:bg-blue-600 text-white px-6 py-2">搜尋</button>
                     <button id="clearButton" class="bg-gray-500 hover:bg-gray-600 text-white px-6 py-2 rounded-r-lg">清除</button>
                 </div>
@@ -133,7 +137,6 @@
 
 <!-- Load Scripts -->
 <script src="nav.js"></script>
-<script src="theme-switcher.js"></script>
 
 <script>
         const rawData = `
@@ -1794,7 +1797,7 @@
                 .join('');
 
             return `
-                <div id="${item.id}" class="item-card rounded-lg p-4 flex flex-col ${isSelected ? 'selected' : ''}" onclick="toggleItemSelection('${item.id}')">
+                <div id="${item.id}" class="item-card rounded-lg p-4 flex flex-col ${isSelected ? 'selected' : ''}" onclick="toggleItemSelection('${item.id}')" role="button" tabindex="0" aria-pressed="${isSelected}">
                     <h3 class="text-xl font-bold mb-2 ${getNameGradientClass(item.itemLevel)}">${item.name}</h3>
                     <div class="text-xs text-slate-400 mb-3 space-x-4">
                         <span>物品等級: ${item.itemLevel}</span>
@@ -1887,6 +1890,7 @@
             const card = document.getElementById(itemId);
             if (card) {
                 card.classList.toggle('selected');
+                card.setAttribute('aria-pressed', card.classList.contains('selected'));
             }
 
             renderComparison();
@@ -1894,6 +1898,7 @@
         
         function deselectAllItems() {
             selectedItems = [];
+            document.querySelectorAll('.item-card').forEach(card => card.setAttribute('aria-pressed', 'false'));
             document.querySelectorAll('.item-card.selected').forEach(card => card.classList.remove('selected'));
             renderComparison();
         }
@@ -1904,6 +1909,12 @@
             renderItems();
             renderComparison();
             
+            document.getElementById('item-groups').addEventListener('keydown', (e) => {
+                if ((e.key === 'Enter' || e.key === ' ') && e.target.classList.contains('item-card')) {
+                    e.preventDefault();
+                    toggleItemSelection(e.target.id);
+                }
+            });
             document.getElementById('deselect-all-btn').addEventListener('click', deselectAllItems);
 
             const searchButton = document.getElementById('searchButton');
@@ -1944,6 +1955,7 @@
 
             clearButton.addEventListener('click', () => {
                 searchInput.value = '';
+                searchInput.focus();
                 showAllItems();
             });
         });


### PR DESCRIPTION
This PR introduces a series of micro-UX and accessibility improvements across the WIKI site:

💡 **Search Discoverability**: Added a keyboard shortcut hint `(按 / 搜尋)` to the search input placeholders in `rich.html`, `aa.html`, and `achievement.html`. This complements the global `/` shortcut already implemented in `nav.js`.

🎯 **Focus Management**: Updated the "Clear" button interaction in `rich.html` and `aa.html`. After clearing the search field, focus is now programmatically returned to the input field, allowing for a seamless transition back to typing.

♿ **Interactive Component Accessibility**: The item cards in the "Accessory Comparison" (`rich.html`) have been upgraded to be fully accessible:
- Added `role="button"` and `tabindex="0"` for keyboard navigation.
- Implemented `aria-pressed` to communicate selection state to screen readers.
- Added keyboard listeners for `Enter` and `Space` to toggle selection.
- Added custom `:focus-visible` styles using the project's existing design tokens.

🧹 **Cleanup**:
- Removed a redundant `<script>` reference to `theme-switcher.js` in `rich.html` (handled by `nav.js`).
- Fixed a CSS syntax error where focus styles were improperly nested.

All changes have been verified using Playwright against a local server environment.

---
*PR created automatically by Jules for task [3214289658801649698](https://jules.google.com/task/3214289658801649698) started by @MisakiYu1003*