### PR TITLE
🎨 Palette: Enhance item card accessibility and search UX in rich.html

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-03-03 - Navigation Accessibility Patterns
 **Learning:** Icon-only buttons (like floating 'Back to Top' and 'Back to Home') and interactive menu toggles require explicit ARIA attributes to be accessible to screen reader users. Specifically, `aria-label` provides a textual alternative, and `aria-expanded` combined with `aria-controls` communicates the state of collapsible menus.
 **Action:** Always include `aria-label` for SVG-only buttons and synchronize `aria-expanded` via JavaScript for any toggle interactions.
+
+## 2026-03-03 - Item Card Interaction Patterns
+**Learning:** Interactive elements implemented as `div` components (like item cards in `rich.html`) must include `tabindex="0"`, `role="button"`, and `aria-pressed` attributes. Keyboard support for 'Enter' and 'Space' should be delegated to the parent container, and focus-visible indicators must be explicitly styled to remain consistent with the accessibility patterns.
+**Action:** Use `setAttribute('aria-pressed', ...)` in JavaScript to toggle selection states and add `outline: 3px solid var(--rich-card-selected-border); outline-offset: 2px;` for custom focus indicators.

--- a/rich.html
+++ b/rich.html
@@ -29,6 +29,10 @@
             border-color: var(--rich-card-selected-border);
             box-shadow: 0 0 15px var(--rich-card-selected-border);
         }
+        .item-card:focus-visible {
+            outline: 3px solid var(--rich-card-selected-border);
+            outline-offset: 2px;
+        }
         .comparison-area {
             background-color: var(--rich-comparison-bg);
             backdrop-filter: blur(10px);
@@ -105,7 +109,7 @@
             <p>點擊物品卡片以加入或移出比較列表。(資料版本為2025/08/01遊戲市中活動擷取)</p>
             <div class="mt-4 max-w-lg mx-auto">
                 <div class="flex">
-                    <input type="text" id="searchInput" class="w-full px-4 py-2 border rounded-l-lg focus:outline-none" placeholder="搜尋飾品名稱或敘述..." style="color: black;">
+                    <input type="text" id="searchInput" class="w-full px-4 py-2 border rounded-l-lg focus:outline-none" placeholder="搜尋飾品名稱或敘述... (按 / 搜尋)" style="color: black;">
                     <button id="searchButton" class="bg-blue-500 hover:bg-blue-600 text-white px-6 py-2">搜尋</button>
                     <button id="clearButton" class="bg-gray-500 hover:bg-gray-600 text-white px-6 py-2 rounded-r-lg">清除</button>
                 </div>
@@ -133,7 +137,6 @@
 
 <!-- Load Scripts -->
 <script src="nav.js"></script>
-<script src="theme-switcher.js"></script>
 
 <script>
         const rawData = `
@@ -1794,7 +1797,7 @@
                 .join('');
 
             return `
-                <div id="${item.id}" class="item-card rounded-lg p-4 flex flex-col ${isSelected ? 'selected' : ''}" onclick="toggleItemSelection('${item.id}')">
+                <div id="${item.id}" class="item-card rounded-lg p-4 flex flex-col ${isSelected ? 'selected' : ''}" onclick="toggleItemSelection('${item.id}')" tabindex="0" role="button" aria-pressed="${isSelected}">
                     <h3 class="text-xl font-bold mb-2 ${getNameGradientClass(item.itemLevel)}">${item.name}</h3>
                     <div class="text-xs text-slate-400 mb-3 space-x-4">
                         <span>物品等級: ${item.itemLevel}</span>
@@ -1886,7 +1889,8 @@
             
             const card = document.getElementById(itemId);
             if (card) {
-                card.classList.toggle('selected');
+                const isSelected = card.classList.toggle('selected');
+                card.setAttribute('aria-pressed', isSelected);
             }
 
             renderComparison();
@@ -1905,6 +1909,14 @@
             renderComparison();
             
             document.getElementById('deselect-all-btn').addEventListener('click', deselectAllItems);
+
+            // Delegated keyboard listener for item cards
+            document.getElementById('item-groups').addEventListener('keydown', (e) => {
+                if ((e.key === 'Enter' || e.key === ' ') && e.target.classList.contains('item-card')) {
+                    e.preventDefault();
+                    e.target.click();
+                }
+            });
 
             const searchButton = document.getElementById('searchButton');
             const searchInput = document.getElementById('searchInput');
@@ -1945,6 +1957,7 @@
             clearButton.addEventListener('click', () => {
                 searchInput.value = '';
                 showAllItems();
+                searchInput.focus();
             });
         });
     </script>


### PR DESCRIPTION
🎨 Palette: Enhance item card accessibility and search UX in rich.html

This change improves the user experience and accessibility of the item comparison page (rich.html):
- Added `tabindex="0"`, `role="button"`, and `aria-pressed` to item cards.
- Implemented keyboard support (Enter/Space) for selecting items via delegation.
- Added custom `:focus-visible` styles for better keyboard navigation visibility.
- Updated search input placeholder with a shortcut hint '(按 / 搜尋)' (shortcut logic is globally implemented in nav.js).
- Ensured focus returns to the search input after clicking the 'Clear' button.
- Removed redundant and non-existent 'theme-switcher.js' script reference (logic is now in nav.js).

All changes were applied surgically to preserve CRLF line endings and minimize diff size. Verified with Playwright tests.

---
*PR created automatically by Jules for task [11563362611858427413](https://jules.google.com/task/11563362611858427413) started by @MisakiYu1003*